### PR TITLE
Remove unused TooltipProvider import

### DIFF
--- a/components/mcp-server-manager.tsx
+++ b/components/mcp-server-manager.tsx
@@ -40,7 +40,6 @@ import { KeyValuePair, MCPServer, ServerStatus, useMCP } from "@/lib/context/mcp
 import {
     Tooltip,
     TooltipContent,
-    TooltipProvider,
     TooltipTrigger,
 } from "./ui/tooltip";
 


### PR DESCRIPTION
## Summary
- trim TooltipProvider from imports in MCP server manager

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*